### PR TITLE
Handles datadir

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,6 +85,7 @@ apps:
       - network
       - network-bind
       - system-observe 
+      - removable-media
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8

--- a/utils/utils.sh
+++ b/utils/utils.sh
@@ -3,7 +3,7 @@
 # Logs to journalctl. Watch with e.g. journalctl -t SNAP_NAME -f
 log()
 {
-    logger -t ${SNAP_NAME} "$1"
+    logger -t ${SNAP_NAME} -- "$1"
 }
 
 restart_reth()


### PR DESCRIPTION
This allows a user to set --datadir to some of the allowed locations:
  /mnt /media /run/media /var/snap/reth/common/datadir

This effectively allows also user to use external disks to store blockchain data.