### PR TITLE
latest version and endure logics

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -15,7 +15,6 @@ handle_service_args_config()
     validate_service_args "$service_args"
     set_service_args "$service_args"
     write_service_args_file
-    restart_polkadot
 }
 
 handle_endure_config()

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+. "$SNAP/utils/utils.sh"
+
+set -e
+log "Initializing default reth snap configuration."
+DATADIR_PATH="$SNAP_COMMON/datadir"
+DEFAULT_SERVICE_ARGS="node --full --datadir $DATADIR_PATH --chain mainnet"
+
+# Set snap Defaults
+snapctl set service-args="$DEFAULT_SERVICE_ARGS"
+log "Setting default service-args: $DEFAULT_SERVICE_ARGS"
+# TODO: Find a way to restart the service despite the snapcraft.yaml endure setting.
+snapctl set endure=true
+log "Setting default endure: true"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,13 +1,12 @@
 #!/bin/sh
 
 . "$SNAP/utils/utils.sh"
-. "$SNAP/utils/endure-utils.sh"
-. "$SNAP/utils/service-args-utils.sh"
+. "$SNAP/utils/endure-utils.sh" 
 
-# Write to service args file to apply any effects from code changes
-write_service_args_file
-
-if ! endure; then
-    log "Restarting reth after a refresh."
-    restart_reth
+if [ $(get_endure) = "true" ]; then
+    log "Endure is enabled, not restarting service."
+    exit 0
+else
+    log "Endure is disabled, restarting service."
+    snapctl restart reth
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
   reth:
     plugin: rust
     source: https://github.com/paradigmxyz/reth.git
-    source-tag: v1.3.12
+    source-tag: v1.6.0
     source-depth: 1
     build-packages:
       - build-essential
@@ -46,7 +46,7 @@ parts:
       rustup install stable
       rustup default stable
       craftctl default
-      craftctl set version="1.3.12-$(git rev-parse --short HEAD)"
+      craftctl set version="1.6.0-$(git rev-parse --short HEAD)"
     override-build: |
       # craftctl default 
       # This will place the reth binary under target/maxperf/reth
@@ -81,12 +81,13 @@ apps:
     daemon: simple
     install-mode: disable
     refresh-mode: endure
-    restart-condition: never
+    restart-condition: on-failure
     plugs:
       - network
       - network-bind
       - system-observe 
       - removable-media
+      - hardware-observe
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8


### PR DESCRIPTION
This deploys version 1.6.0 of reth and also makes the endure work as expected.